### PR TITLE
Drop support for netcoreapp2.1 and switch to netstandard3.1

### DIFF
--- a/Test/Directory.Build.props
+++ b/Test/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>2.4.0</Version>
     <PackageProjectUrl>https://github.com/RayTale/Ray</PackageProjectUrl>

--- a/src/Ray.Core/Ray.Core.csproj
+++ b/src/Ray.Core/Ray.Core.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Orleans.Core" Version="3.2.1" />
     <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
   </ItemGroup>


### PR DESCRIPTION
This is a PR for #44 

Feel free to reject this PR if you need to maintains support for `netcoreapp2.2`.

