### PR TITLE
Bump Prometheus.Client to 4.1.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -30,9 +30,9 @@
     <PackageReference Update="Npgsql" Version="4.1.4" />
     <PackageReference Update="MySqlConnector" Version="1.0.1" />
     <PackageReference Update="MongoDB.Driver" Version="2.11.0" />
-    <PackageReference Update="Prometheus.Client" Version="3.1.0" />
-    <PackageReference Update="Prometheus.Client.MetricPusher" Version="1.1.0" />
-    <PackageReference Update="Prometheus.Client.MetricServer" Version="3.1.0" />
+    <PackageReference Update="Prometheus.Client" Version="4.1.0" />
+    <PackageReference Update="Prometheus.Client.DependencyInjection" Version="0.1.0" />
+    <PackageReference Update="Prometheus.Client.MetricPusher" Version="2.0.0" />
     <PackageReference Update="System.Reactive" Version="4.4.1" />
 
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="All" />

--- a/src/Ray.Metric.Prometheus/Extensions.cs
+++ b/src/Ray.Metric.Prometheus/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Hosting;
+using Prometheus.Client.DependencyInjection;
 using Ray.Metric.Core;
 using Ray.Metric.Prometheus.MetricHandler;
 
@@ -14,6 +15,7 @@ namespace Ray.Metric.Prometheus
         {
             builder.ConfigureServices(serviceCollection =>
             {
+                serviceCollection.AddMetricFactory();
                 serviceCollection.Configure<MetricOption>(config => configAction(config));
                 serviceCollection.AddHostedService<MetricPushService>();
                 serviceCollection.AddSingleton<IMetricStream, PrometheusMetricStream>();

--- a/src/Ray.Metric.Prometheus/MetricHandler/ActorMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/ActorMetricHandler.cs
@@ -1,26 +1,28 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class ActorMetricHandler
     {
-        private readonly Gauge ActorMetricMaxEventsPerActorGauge;
-        private readonly Gauge ActorMetricAvgEventsPerActorGauge;
-        private readonly Gauge ActorMetricMinEventsPerActorGauge;
-        private readonly Gauge ActorMetricLivesGauge;
-        private readonly Gauge ActorMetricIgnoresGauge;
-        private readonly Gauge ActorMetricEventsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> ActorMetricMaxEventsPerActorGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> ActorMetricAvgEventsPerActorGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> ActorMetricMinEventsPerActorGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> ActorMetricLivesGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> ActorMetricIgnoresGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> ActorMetricEventsGauge;
 
-        public ActorMetricHandler()
+        public ActorMetricHandler(IMetricFactory metricFactory)
         {
-            this.ActorMetricMaxEventsPerActorGauge = Metrics.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.MaxEventsPerActor)}", string.Empty, nameof(ActorMetric.Actor));
-            this.ActorMetricAvgEventsPerActorGauge = Metrics.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.AvgEventsPerActor)}", string.Empty, nameof(ActorMetric.Actor));
-            this.ActorMetricMinEventsPerActorGauge = Metrics.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.MinEventsPerActor)}", string.Empty, nameof(ActorMetric.Actor));
-            this.ActorMetricLivesGauge = Metrics.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.Lives)}", string.Empty, nameof(ActorMetric.Actor));
-            this.ActorMetricIgnoresGauge = Metrics.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.Ignores)}", string.Empty, nameof(ActorMetric.Actor));
-            this.ActorMetricEventsGauge = Metrics.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.Events)}", string.Empty, nameof(ActorMetric.Actor));
+            this.ActorMetricMaxEventsPerActorGauge = metricFactory.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.MaxEventsPerActor)}", string.Empty, nameof(ActorMetric.Actor));
+            this.ActorMetricAvgEventsPerActorGauge = metricFactory.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.AvgEventsPerActor)}", string.Empty, nameof(ActorMetric.Actor));
+            this.ActorMetricMinEventsPerActorGauge = metricFactory.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.MinEventsPerActor)}", string.Empty, nameof(ActorMetric.Actor));
+            this.ActorMetricLivesGauge = metricFactory.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.Lives)}", string.Empty, nameof(ActorMetric.Actor));
+            this.ActorMetricIgnoresGauge = metricFactory.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.Ignores)}", string.Empty, nameof(ActorMetric.Actor));
+            this.ActorMetricEventsGauge = metricFactory.CreateGauge($"{nameof(ActorMetric)}_{nameof(ActorMetric.Events)}", string.Empty, nameof(ActorMetric.Actor));
         }
 
         public void Handle(List<ActorMetric> actorMetrics)

--- a/src/Ray.Metric.Prometheus/MetricHandler/DtxMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/DtxMetricHandler.cs
@@ -1,26 +1,28 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class DtxMetricHandler
     {
-        private readonly Gauge DtxMetricMaxElapsedMsGauge;
-        private readonly Gauge DtxMetricAvgElapsedMsGauge;
-        private readonly Gauge DtxMetricMinElapsedMsGauge;
-        private readonly Gauge DtxMetricTimesGauge;
-        private readonly Gauge DtxMetricCommitsGauge;
-        private readonly Gauge DtxMetricRollbacksGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> DtxMetricMaxElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> DtxMetricAvgElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> DtxMetricMinElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> DtxMetricTimesGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> DtxMetricCommitsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> DtxMetricRollbacksGauge;
 
-        public DtxMetricHandler()
+        public DtxMetricHandler(IMetricFactory metricFactory)
         {
-            this.DtxMetricMaxElapsedMsGauge = Metrics.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.MaxElapsedMs)}", string.Empty, nameof(DtxMetric.Actor));
-            this.DtxMetricAvgElapsedMsGauge = Metrics.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.AvgElapsedMs)}", string.Empty, nameof(DtxMetric.Actor));
-            this.DtxMetricMinElapsedMsGauge = Metrics.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.MinElapsedMs)}", string.Empty, nameof(DtxMetric.Actor));
-            this.DtxMetricTimesGauge = Metrics.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.Times)}", string.Empty, nameof(DtxMetric.Actor));
-            this.DtxMetricCommitsGauge = Metrics.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.Commits)}", string.Empty, nameof(DtxMetric.Actor));
-            this.DtxMetricRollbacksGauge = Metrics.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.Rollbacks)}", string.Empty, nameof(DtxMetric.Actor));
+            this.DtxMetricMaxElapsedMsGauge = metricFactory.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.MaxElapsedMs)}", string.Empty, nameof(DtxMetric.Actor));
+            this.DtxMetricAvgElapsedMsGauge = metricFactory.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.AvgElapsedMs)}", string.Empty, nameof(DtxMetric.Actor));
+            this.DtxMetricMinElapsedMsGauge = metricFactory.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.MinElapsedMs)}", string.Empty, nameof(DtxMetric.Actor));
+            this.DtxMetricTimesGauge = metricFactory.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.Times)}", string.Empty, nameof(DtxMetric.Actor));
+            this.DtxMetricCommitsGauge = metricFactory.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.Commits)}", string.Empty, nameof(DtxMetric.Actor));
+            this.DtxMetricRollbacksGauge = metricFactory.CreateGauge($"{nameof(DtxMetric)}_{nameof(DtxMetric.Rollbacks)}", string.Empty, nameof(DtxMetric.Actor));
         }
 
         public void Handle(List<DtxMetric> DtxMetrics)

--- a/src/Ray.Metric.Prometheus/MetricHandler/DtxSummaryMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/DtxSummaryMetricHandler.cs
@@ -1,25 +1,25 @@
-﻿using Prometheus.Client;
+﻿using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class DtxSummaryMetricHandler
     {
-        private readonly Gauge DtxSummaryMetricMaxElapsedMsGauge;
-        private readonly Gauge DtxSummaryMetricAvgElapsedMsGauge;
-        private readonly Gauge DtxSummaryMetricMinElapsedMsGauge;
-        private readonly Gauge DtxSummaryMetricTimesGauge;
-        private readonly Gauge DtxSummaryMetricCommitsGauge;
-        private readonly Gauge DtxSummaryMetricRollbacksGauge;
+        private readonly IGauge DtxSummaryMetricMaxElapsedMsGauge;
+        private readonly IGauge DtxSummaryMetricAvgElapsedMsGauge;
+        private readonly IGauge DtxSummaryMetricMinElapsedMsGauge;
+        private readonly IGauge DtxSummaryMetricTimesGauge;
+        private readonly IGauge DtxSummaryMetricCommitsGauge;
+        private readonly IGauge DtxSummaryMetricRollbacksGauge;
 
-        public DtxSummaryMetricHandler()
+        public DtxSummaryMetricHandler(IMetricFactory metricFactory)
         {
-            this.DtxSummaryMetricMaxElapsedMsGauge = Metrics.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.MaxElapsedMs)}", string.Empty);
-            this.DtxSummaryMetricAvgElapsedMsGauge = Metrics.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.AvgElapsedMs)}", string.Empty);
-            this.DtxSummaryMetricMinElapsedMsGauge = Metrics.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.MinElapsedMs)}", string.Empty);
-            this.DtxSummaryMetricTimesGauge = Metrics.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.Times)}", string.Empty);
-            this.DtxSummaryMetricCommitsGauge = Metrics.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.Commits)}", string.Empty);
-            this.DtxSummaryMetricRollbacksGauge = Metrics.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.Rollbacks)}", string.Empty);
+            this.DtxSummaryMetricMaxElapsedMsGauge = metricFactory.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.MaxElapsedMs)}", string.Empty);
+            this.DtxSummaryMetricAvgElapsedMsGauge = metricFactory.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.AvgElapsedMs)}", string.Empty);
+            this.DtxSummaryMetricMinElapsedMsGauge = metricFactory.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.MinElapsedMs)}", string.Empty);
+            this.DtxSummaryMetricTimesGauge = metricFactory.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.Times)}", string.Empty);
+            this.DtxSummaryMetricCommitsGauge = metricFactory.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.Commits)}", string.Empty);
+            this.DtxSummaryMetricRollbacksGauge = metricFactory.CreateGauge($"{nameof(DtxSummaryMetric)}_{nameof(DtxSummaryMetric.Rollbacks)}", string.Empty);
         }
 
         public void Handle(DtxSummaryMetric dtxSummaryMetrics)

--- a/src/Ray.Metric.Prometheus/MetricHandler/EventLinkMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/EventLinkMetricHandler.cs
@@ -1,35 +1,38 @@
 ﻿using System.Collections.Generic;
-using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class EventLinkMetricHandler
     {
-        private readonly Gauge EventLinkMetricCountGauge;
-        private readonly Gauge EventLinkMetricMaxElapsedMsGauge;
-        private readonly Gauge EventLinkMetricMinElapsedMsGauge;
-        private readonly Gauge EventLinkMetricAvgElapsedMsGauge;
-        private readonly Gauge EventLinkMetricIgnoresGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string ParentActor, string ParentEvent)> EventLinkMetricCountGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string ParentActor, string ParentEvent)> EventLinkMetricMaxElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string ParentActor, string ParentEvent)> EventLinkMetricMinElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string ParentActor, string ParentEvent)> EventLinkMetricAvgElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string ParentActor, string ParentEvent)> EventLinkMetricIgnoresGauge;
 
-        public EventLinkMetricHandler()
+        public EventLinkMetricHandler(IMetricFactory metricFactory)
         {
-            this.EventLinkMetricCountGauge = Metrics.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.Events)}", string.Empty, nameof(EventLinkMetric.Actor), nameof(EventLinkMetric.Event), nameof(EventLinkMetric.ParentActor), nameof(EventLinkMetric.ParentEvent));
-            this.EventLinkMetricMaxElapsedMsGauge = Metrics.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.MaxElapsedMs)}", string.Empty, nameof(EventLinkMetric.Actor), nameof(EventLinkMetric.Event), nameof(EventLinkMetric.ParentActor), nameof(EventLinkMetric.ParentEvent));
-            this.EventLinkMetricMinElapsedMsGauge = Metrics.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.MinElapsedMs)}", string.Empty, nameof(EventLinkMetric.Actor), nameof(EventLinkMetric.Event), nameof(EventLinkMetric.ParentActor), nameof(EventLinkMetric.ParentEvent));
-            this.EventLinkMetricAvgElapsedMsGauge = Metrics.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.AvgElapsedMs)}", string.Empty, nameof(EventLinkMetric.Actor), nameof(EventLinkMetric.Event), nameof(EventLinkMetric.ParentActor), nameof(EventLinkMetric.ParentEvent));
-            this.EventLinkMetricIgnoresGauge = Metrics.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.Ignores)}", string.Empty, nameof(EventLinkMetric.Actor), nameof(EventLinkMetric.Event), nameof(EventLinkMetric.ParentActor), nameof(EventLinkMetric.ParentEvent));
+            var labelNames = (nameof(EventLinkMetric.Actor), nameof(EventLinkMetric.Event), nameof(EventLinkMetric.ParentActor), nameof(EventLinkMetric.ParentEvent));
+            this.EventLinkMetricCountGauge = metricFactory.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.Events)}", string.Empty, labelNames);
+            this.EventLinkMetricMaxElapsedMsGauge = metricFactory.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.MaxElapsedMs)}", string.Empty, labelNames);
+            this.EventLinkMetricMinElapsedMsGauge = metricFactory.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.MinElapsedMs)}", string.Empty, labelNames);
+            this.EventLinkMetricAvgElapsedMsGauge = metricFactory.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.AvgElapsedMs)}", string.Empty, labelNames);
+            this.EventLinkMetricIgnoresGauge = metricFactory.CreateGauge($"{nameof(EventLinkMetric)}_{nameof(EventLinkMetric.Ignores)}", string.Empty, labelNames);
         }
 
         public void Handle(List<EventLinkMetric> eventMetrics)
         {
             foreach (var item in eventMetrics)
             {
-                this.EventLinkMetricCountGauge.WithLabels(item.Actor, item.Event, item.ParentActor ?? string.Empty, item.ParentEvent ?? string.Empty).Set(item.Events, item.Timestamp);
-                this.EventLinkMetricMaxElapsedMsGauge.WithLabels(item.Actor, item.Event, item.ParentActor ?? string.Empty, item.ParentEvent ?? string.Empty).Set(item.MaxElapsedMs, item.Timestamp);
-                this.EventLinkMetricMinElapsedMsGauge.WithLabels(item.Actor, item.Event, item.ParentActor ?? string.Empty, item.ParentEvent ?? string.Empty).Set(item.MinElapsedMs, item.Timestamp);
-                this.EventLinkMetricAvgElapsedMsGauge.WithLabels(item.Actor, item.Event, item.ParentActor ?? string.Empty, item.ParentEvent ?? string.Empty).Set(item.AvgElapsedMs, item.Timestamp);
-                this.EventLinkMetricIgnoresGauge.WithLabels(item.Actor, item.Event, item.ParentActor ?? string.Empty, item.ParentEvent ?? string.Empty).Set(item.Ignores, item.Timestamp);
+                var labels = (item.Actor, item.Event, item.ParentActor ?? string.Empty, item.ParentEvent ?? string.Empty);
+
+                this.EventLinkMetricCountGauge.WithLabels(labels).Set(item.Events, item.Timestamp);
+                this.EventLinkMetricMaxElapsedMsGauge.WithLabels(labels).Set(item.MaxElapsedMs, item.Timestamp);
+                this.EventLinkMetricMinElapsedMsGauge.WithLabels(labels).Set(item.MinElapsedMs, item.Timestamp);
+                this.EventLinkMetricAvgElapsedMsGauge.WithLabels(labels).Set(item.AvgElapsedMs, item.Timestamp);
+                this.EventLinkMetricIgnoresGauge.WithLabels(labels).Set(item.Ignores, item.Timestamp);
             }
         }
     }

--- a/src/Ray.Metric.Prometheus/MetricHandler/EventMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/EventMetricHandler.cs
@@ -1,44 +1,48 @@
 ﻿using System.Collections.Generic;
-using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class EventMetricHandler
     {
-        private readonly Gauge EventCountGauge;
-        private readonly Gauge EventMaxPerActorGauge;
-        private readonly Gauge EventAvgPerActorGauge;
-        private readonly Gauge EventMinPerActorGauge;
-        private readonly Gauge EventMaxInsertElapsedMsGauge;
-        private readonly Gauge EventAvgInsertElapsedMsGauge;
-        private readonly Gauge EventMinInsertElapsedMsGauge;
-        private readonly Gauge EventIgnoresGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventCountGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventMaxPerActorGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventAvgPerActorGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventMinPerActorGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventMaxInsertElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventAvgInsertElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventMinInsertElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event)> EventIgnoresGauge;
 
-        public EventMetricHandler()
+        public EventMetricHandler(IMetricFactory metricFactory)
         {
-            this.EventCountGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.Events)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
-            this.EventMaxPerActorGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MaxPerActor)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
-            this.EventAvgPerActorGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.AvgPerActor)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
-            this.EventMinPerActorGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MinPerActor)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
-            this.EventMaxInsertElapsedMsGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MaxInsertElapsedMs)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
-            this.EventAvgInsertElapsedMsGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.AvgInsertElapsedMs)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
-            this.EventMinInsertElapsedMsGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MinInsertElapsedMs)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
-            this.EventIgnoresGauge = Metrics.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.Ignores)}", string.Empty, nameof(EventMetric.Actor), nameof(EventMetric.Event));
+            var labelNames = (nameof(EventMetric.Actor), nameof(EventMetric.Event));
+
+            this.EventCountGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.Events)}", string.Empty, labelNames);
+            this.EventMaxPerActorGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MaxPerActor)}", string.Empty, labelNames);
+            this.EventAvgPerActorGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.AvgPerActor)}", string.Empty, labelNames);
+            this.EventMinPerActorGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MinPerActor)}", string.Empty, labelNames);
+            this.EventMaxInsertElapsedMsGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MaxInsertElapsedMs)}", string.Empty, labelNames);
+            this.EventAvgInsertElapsedMsGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.AvgInsertElapsedMs)}", string.Empty, labelNames);
+            this.EventMinInsertElapsedMsGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.MinInsertElapsedMs)}", string.Empty, labelNames);
+            this.EventIgnoresGauge = metricFactory.CreateGauge($"{nameof(EventMetric)}_{nameof(EventMetric.Ignores)}", string.Empty, labelNames);
         }
 
         public void Handle(List<EventMetric> eventMetrics)
         {
             foreach (var item in eventMetrics)
             {
-                this.EventCountGauge.WithLabels(item.Actor, item.Event).Set(item.Events, item.Timestamp);
-                this.EventMaxPerActorGauge.WithLabels(item.Actor, item.Event).Set(item.MaxPerActor, item.Timestamp);
-                this.EventAvgPerActorGauge.WithLabels(item.Actor, item.Event).Set(item.AvgPerActor, item.Timestamp);
-                this.EventMinPerActorGauge.WithLabels(item.Actor, item.Event).Set(item.MinPerActor, item.Timestamp);
-                this.EventMaxInsertElapsedMsGauge.WithLabels(item.Actor, item.Event).Set(item.MaxInsertElapsedMs, item.Timestamp);
-                this.EventAvgInsertElapsedMsGauge.WithLabels(item.Actor, item.Event).Set(item.AvgInsertElapsedMs, item.Timestamp);
-                this.EventMinInsertElapsedMsGauge.WithLabels(item.Actor, item.Event).Set(item.MinInsertElapsedMs, item.Timestamp);
-                this.EventIgnoresGauge.WithLabels(item.Actor, item.Event).Set(item.Ignores, item.Timestamp);
+                var labels = (item.Actor, item.Event);
+                
+                this.EventCountGauge.WithLabels(labels).Set(item.Events, item.Timestamp);
+                this.EventMaxPerActorGauge.WithLabels(labels).Set(item.MaxPerActor, item.Timestamp);
+                this.EventAvgPerActorGauge.WithLabels(labels).Set(item.AvgPerActor, item.Timestamp);
+                this.EventMinPerActorGauge.WithLabels(labels).Set(item.MinPerActor, item.Timestamp);
+                this.EventMaxInsertElapsedMsGauge.WithLabels(labels).Set(item.MaxInsertElapsedMs, item.Timestamp);
+                this.EventAvgInsertElapsedMsGauge.WithLabels(labels).Set(item.AvgInsertElapsedMs, item.Timestamp);
+                this.EventMinInsertElapsedMsGauge.WithLabels(labels).Set(item.MinInsertElapsedMs, item.Timestamp);
+                this.EventIgnoresGauge.WithLabels(labels).Set(item.Ignores, item.Timestamp);
             }
         }
     }

--- a/src/Ray.Metric.Prometheus/MetricHandler/EventSummaryMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/EventSummaryMetricHandler.cs
@@ -1,25 +1,25 @@
-﻿using Prometheus.Client;
+﻿using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class EventSummaryMetricHandler
     {
-        private readonly Gauge EventSummaryMetricMaxEventsPerActorGauge;
-        private readonly Gauge EventSummaryMetricAvgEventsPerActorGauge;
-        private readonly Gauge EventSummaryMetricMinEventsPerActorGauge;
-        private readonly Gauge EventSummaryMetricLivesGauge;
-        private readonly Gauge EventSummaryMetricIgnoresGauge;
-        private readonly Gauge EventSummaryMetricEventsGauge;
+        private readonly IGauge EventSummaryMetricMaxEventsPerActorGauge;
+        private readonly IGauge EventSummaryMetricAvgEventsPerActorGauge;
+        private readonly IGauge EventSummaryMetricMinEventsPerActorGauge;
+        private readonly IGauge EventSummaryMetricLivesGauge;
+        private readonly IGauge EventSummaryMetricIgnoresGauge;
+        private readonly IGauge EventSummaryMetricEventsGauge;
 
-        public EventSummaryMetricHandler()
+        public EventSummaryMetricHandler(IMetricFactory metricFactory)
         {
-            this.EventSummaryMetricMaxEventsPerActorGauge = Metrics.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.MaxEventsPerActor)}", string.Empty);
-            this.EventSummaryMetricAvgEventsPerActorGauge = Metrics.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.AvgEventsPerActor)}", string.Empty);
-            this.EventSummaryMetricMinEventsPerActorGauge = Metrics.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.MinEventsPerActor)}", string.Empty);
-            this.EventSummaryMetricLivesGauge = Metrics.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.ActorLives)}", string.Empty);
-            this.EventSummaryMetricIgnoresGauge = Metrics.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.Ignores)}", string.Empty);
-            this.EventSummaryMetricEventsGauge = Metrics.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.Events)}", string.Empty);
+            this.EventSummaryMetricMaxEventsPerActorGauge = metricFactory.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.MaxEventsPerActor)}", string.Empty);
+            this.EventSummaryMetricAvgEventsPerActorGauge = metricFactory.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.AvgEventsPerActor)}", string.Empty);
+            this.EventSummaryMetricMinEventsPerActorGauge = metricFactory.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.MinEventsPerActor)}", string.Empty);
+            this.EventSummaryMetricLivesGauge = metricFactory.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.ActorLives)}", string.Empty);
+            this.EventSummaryMetricIgnoresGauge = metricFactory.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.Ignores)}", string.Empty);
+            this.EventSummaryMetricEventsGauge = metricFactory.CreateGauge($"{nameof(EventSummaryMetric)}_{nameof(EventSummaryMetric.Events)}", string.Empty);
         }
 
         public void Handle(EventSummaryMetric summaryMetric)

--- a/src/Ray.Metric.Prometheus/MetricHandler/FollowActorMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/FollowActorMetricHandler.cs
@@ -1,32 +1,36 @@
 ﻿using System.Collections.Generic;
-using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class FollowActorMetricHandler
     {
-        private readonly Gauge FollowActorMetricCountGauge;
-        private readonly Gauge FollowActorMetricMaxElapsedMsGauge;
-        private readonly Gauge FollowActorMetricAvgElapsedMsGauge;
-        private readonly Gauge FollowActorMetricMinElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string FromActor)> FollowActorMetricCountGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string FromActor)> FollowActorMetricMaxElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string FromActor)> FollowActorMetricAvgElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string FromActor)> FollowActorMetricMinElapsedMsGauge;
 
-        public FollowActorMetricHandler()
+        public FollowActorMetricHandler(IMetricFactory metricFactory)
         {
-            this.FollowActorMetricCountGauge = Metrics.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.Events)}", string.Empty, nameof(FollowActorMetric.Actor), nameof(FollowActorMetric.FromActor));
-            this.FollowActorMetricMaxElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.MaxElapsedMs)}", string.Empty, nameof(FollowActorMetric.Actor), nameof(FollowActorMetric.FromActor));
-            this.FollowActorMetricAvgElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.AvgElapsedMs)}", string.Empty, nameof(FollowActorMetric.Actor), nameof(FollowActorMetric.FromActor));
-            this.FollowActorMetricMinElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.MinElapsedMs)}", string.Empty, nameof(FollowActorMetric.Actor), nameof(FollowActorMetric.FromActor));
+            var labelNames = (nameof(FollowActorMetric.Actor), nameof(FollowActorMetric.FromActor));
+
+            this.FollowActorMetricCountGauge = metricFactory.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.Events)}", string.Empty, labelNames);
+            this.FollowActorMetricMaxElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.MaxElapsedMs)}", string.Empty, labelNames);
+            this.FollowActorMetricAvgElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.AvgElapsedMs)}", string.Empty, labelNames);
+            this.FollowActorMetricMinElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowActorMetric)}_{nameof(FollowActorMetric.MinElapsedMs)}", string.Empty, labelNames);
         }
 
         public void Handle(List<FollowActorMetric> followActorMetrics)
         {
             foreach (var item in followActorMetrics)
             {
-                this.FollowActorMetricCountGauge.WithLabels(item.Actor, item.FromActor).Set(item.Events, item.Timestamp);
-                this.FollowActorMetricMaxElapsedMsGauge.WithLabels(item.Actor, item.FromActor).Set(item.MaxElapsedMs, item.Timestamp);
-                this.FollowActorMetricAvgElapsedMsGauge.WithLabels(item.Actor, item.FromActor).Set(item.AvgElapsedMs, item.Timestamp);
-                this.FollowActorMetricMinElapsedMsGauge.WithLabels(item.Actor, item.FromActor).Set(item.MinElapsedMs, item.Timestamp);
+                var labels = (item.Actor, item.FromActor);
+                
+                this.FollowActorMetricCountGauge.WithLabels(labels).Set(item.Events, item.Timestamp);
+                this.FollowActorMetricMaxElapsedMsGauge.WithLabels(labels).Set(item.MaxElapsedMs, item.Timestamp);
+                this.FollowActorMetricAvgElapsedMsGauge.WithLabels(labels).Set(item.AvgElapsedMs, item.Timestamp);
+                this.FollowActorMetricMinElapsedMsGauge.WithLabels(labels).Set(item.MinElapsedMs, item.Timestamp);
             }
         }
     }

--- a/src/Ray.Metric.Prometheus/MetricHandler/FollowEventMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/FollowEventMetricHandler.cs
@@ -1,41 +1,45 @@
 ﻿using System.Collections.Generic;
-using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class FollowFollowEventMetricHandler
     {
-        private readonly Gauge FollowEventMetricCountGauge;
-        private readonly Gauge FollowEventMetricMaxElapsedMsGauge;
-        private readonly Gauge FollowEventMetricAvgElapsedMsGauge;
-        private readonly Gauge FollowEventMetricMinElapsedMsGauge;
-        private readonly Gauge FollowEventMetricMaxDeliveryElapsedMsGauge;
-        private readonly Gauge FollowEventMetricAvgDeliveryElapsedMsGauge;
-        private readonly Gauge FollowEventMetricMinDeliveryElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string FromActor)> FollowEventMetricCountGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string FromActor)> FollowEventMetricMaxElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string FromActor)> FollowEventMetricAvgElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string FromActor)> FollowEventMetricMinElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string FromActor)> FollowEventMetricMaxDeliveryElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string FromActor)> FollowEventMetricAvgDeliveryElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Event, string FromActor)> FollowEventMetricMinDeliveryElapsedMsGauge;
 
-        public FollowFollowEventMetricHandler()
+        public FollowFollowEventMetricHandler(IMetricFactory metricFactory)
         {
-            this.FollowEventMetricCountGauge = Metrics.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.Events)}", string.Empty, nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
-            this.FollowEventMetricMaxElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MaxElapsedMs)}", string.Empty, nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
-            this.FollowEventMetricAvgElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.AvgElapsedMs)}", string.Empty, nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
-            this.FollowEventMetricMinElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MinElapsedMs)}", string.Empty, nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
-            this.FollowEventMetricMaxDeliveryElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MaxDeliveryElapsedMs)}", string.Empty, nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
-            this.FollowEventMetricAvgDeliveryElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.AvgDeliveryElapsedMs)}", string.Empty, nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
-            this.FollowEventMetricMinDeliveryElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MinDeliveryElapsedMs)}", string.Empty, nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
+            var labelNames = (nameof(FollowEventMetric.Actor), nameof(FollowEventMetric.Event), nameof(FollowEventMetric.FromActor));
+            
+            this.FollowEventMetricCountGauge = metricFactory.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.Events)}", string.Empty, labelNames);
+            this.FollowEventMetricMaxElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MaxElapsedMs)}", string.Empty, labelNames);
+            this.FollowEventMetricAvgElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.AvgElapsedMs)}", string.Empty, labelNames);
+            this.FollowEventMetricMinElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MinElapsedMs)}", string.Empty, labelNames);
+            this.FollowEventMetricMaxDeliveryElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MaxDeliveryElapsedMs)}", string.Empty, labelNames);
+            this.FollowEventMetricAvgDeliveryElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.AvgDeliveryElapsedMs)}", string.Empty, labelNames);
+            this.FollowEventMetricMinDeliveryElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowEventMetric)}_{nameof(FollowEventMetric.MinDeliveryElapsedMs)}", string.Empty, labelNames);
         }
 
         public void Handle(List<FollowEventMetric> followEventMetrics)
         {
             foreach (var item in followEventMetrics)
             {
-                this.FollowEventMetricCountGauge.WithLabels(item.Actor, item.Event, item.FromActor).Set(item.Events, item.Timestamp);
-                this.FollowEventMetricMaxElapsedMsGauge.WithLabels(item.Actor, item.Event, item.FromActor).Set(item.MaxElapsedMs, item.Timestamp);
-                this.FollowEventMetricAvgElapsedMsGauge.WithLabels(item.Actor, item.Event, item.FromActor).Set(item.AvgElapsedMs, item.Timestamp);
-                this.FollowEventMetricMinElapsedMsGauge.WithLabels(item.Actor, item.Event, item.FromActor).Set(item.MinElapsedMs, item.Timestamp);
-                this.FollowEventMetricMaxDeliveryElapsedMsGauge.WithLabels(item.Actor, item.Event, item.FromActor).Set(item.MaxDeliveryElapsedMs, item.Timestamp);
-                this.FollowEventMetricAvgDeliveryElapsedMsGauge.WithLabels(item.Actor, item.Event, item.FromActor).Set(item.AvgDeliveryElapsedMs, item.Timestamp);
-                this.FollowEventMetricMinDeliveryElapsedMsGauge.WithLabels(item.Actor, item.Event, item.FromActor).Set(item.MinDeliveryElapsedMs, item.Timestamp);
+                var labels = (item.Actor, item.Event, item.FromActor);
+                
+                this.FollowEventMetricCountGauge.WithLabels(labels).Set(item.Events, item.Timestamp);
+                this.FollowEventMetricMaxElapsedMsGauge.WithLabels(labels).Set(item.MaxElapsedMs, item.Timestamp);
+                this.FollowEventMetricAvgElapsedMsGauge.WithLabels(labels).Set(item.AvgElapsedMs, item.Timestamp);
+                this.FollowEventMetricMinElapsedMsGauge.WithLabels(labels).Set(item.MinElapsedMs, item.Timestamp);
+                this.FollowEventMetricMaxDeliveryElapsedMsGauge.WithLabels(labels).Set(item.MaxDeliveryElapsedMs, item.Timestamp);
+                this.FollowEventMetricAvgDeliveryElapsedMsGauge.WithLabels(labels).Set(item.AvgDeliveryElapsedMs, item.Timestamp);
+                this.FollowEventMetricMinDeliveryElapsedMsGauge.WithLabels(labels).Set(item.MinDeliveryElapsedMs, item.Timestamp);
             }
         }
     }

--- a/src/Ray.Metric.Prometheus/MetricHandler/FollowGroupMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/FollowGroupMetricHandler.cs
@@ -1,28 +1,30 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class FollowGroupMetricHandler
     {
-        private readonly Gauge FollowGroupMetricCountGauge;
-        private readonly Gauge FollowGroupMetricMaxElapsedMsGauge;
-        private readonly Gauge FollowGroupMetricAvgElapsedMsGauge;
-        private readonly Gauge FollowGroupMetricMinElapsedMsGauge;
-        private readonly Gauge FollowGroupMetricMaxDeliveryElapsedMsGauge;
-        private readonly Gauge FollowGroupMetricAvgDeliveryElapsedMsGauge;
-        private readonly Gauge FollowGroupMetricMinDeliveryElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> FollowGroupMetricCountGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> FollowGroupMetricMaxElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> FollowGroupMetricAvgElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> FollowGroupMetricMinElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> FollowGroupMetricMaxDeliveryElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> FollowGroupMetricAvgDeliveryElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, ValueTuple<string>> FollowGroupMetricMinDeliveryElapsedMsGauge;
 
-        public FollowGroupMetricHandler()
+        public FollowGroupMetricHandler(IMetricFactory metricFactory)
         {
-            this.FollowGroupMetricCountGauge = Metrics.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.Events)}", string.Empty, nameof(FollowGroupMetric.Group));
-            this.FollowGroupMetricMaxElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MaxElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
-            this.FollowGroupMetricAvgElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.AvgElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
-            this.FollowGroupMetricMinElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MinElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
-            this.FollowGroupMetricMaxDeliveryElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MaxDeliveryElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
-            this.FollowGroupMetricAvgDeliveryElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.AvgDeliveryElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
-            this.FollowGroupMetricMinDeliveryElapsedMsGauge = Metrics.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MinDeliveryElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
+            this.FollowGroupMetricCountGauge = metricFactory.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.Events)}", string.Empty, nameof(FollowGroupMetric.Group));
+            this.FollowGroupMetricMaxElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MaxElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
+            this.FollowGroupMetricAvgElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.AvgElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
+            this.FollowGroupMetricMinElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MinElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
+            this.FollowGroupMetricMaxDeliveryElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MaxDeliveryElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
+            this.FollowGroupMetricAvgDeliveryElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.AvgDeliveryElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
+            this.FollowGroupMetricMinDeliveryElapsedMsGauge = metricFactory.CreateGauge($"{nameof(FollowGroupMetric)}_{nameof(FollowGroupMetric.MinDeliveryElapsedMs)}", string.Empty, nameof(FollowGroupMetric.Group));
         }
 
         public void Handle(List<FollowGroupMetric> followGroupMetrics)

--- a/src/Ray.Metric.Prometheus/MetricHandler/SnapshotMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/SnapshotMetricHandler.cs
@@ -1,41 +1,45 @@
 ﻿using System.Collections.Generic;
-using Prometheus.Client;
+using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class SnapshotMetricHandler
     {
-        private readonly Gauge SnapshotMetricSaveCountGauge;
-        private readonly Gauge SnapshotMetricMaxElapsedVersionGauge;
-        private readonly Gauge SnapshotMetricAvgElapsedVersionGauge;
-        private readonly Gauge SnapshotMetricMinElapsedVersionGauge;
-        private readonly Gauge SnapshotMetricMaxSaveElapsedMsGauge;
-        private readonly Gauge SnapshotMetricAvgSaveElapsedMsGauge;
-        private readonly Gauge SnapshotMetricMinSaveElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Snapshot)> SnapshotMetricSaveCountGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Snapshot)> SnapshotMetricMaxElapsedVersionGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Snapshot)> SnapshotMetricAvgElapsedVersionGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Snapshot)> SnapshotMetricMinElapsedVersionGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Snapshot)> SnapshotMetricMaxSaveElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Snapshot)> SnapshotMetricAvgSaveElapsedMsGauge;
+        private readonly IMetricFamily<IGauge, (string Actor, string Snapshot)> SnapshotMetricMinSaveElapsedMsGauge;
 
-        public SnapshotMetricHandler()
+        public SnapshotMetricHandler(IMetricFactory metricFactory)
         {
-            this.SnapshotMetricSaveCountGauge = Metrics.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.SaveCount)}", string.Empty, nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
-            this.SnapshotMetricMaxElapsedVersionGauge = Metrics.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MaxElapsedVersion)}", string.Empty, nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
-            this.SnapshotMetricAvgElapsedVersionGauge = Metrics.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.AvgElapsedVersion)}", string.Empty, nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
-            this.SnapshotMetricMinElapsedVersionGauge = Metrics.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MinElapsedVersion)}", string.Empty, nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
-            this.SnapshotMetricMaxSaveElapsedMsGauge = Metrics.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MaxSaveElapsedMs)}", string.Empty, nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
-            this.SnapshotMetricAvgSaveElapsedMsGauge = Metrics.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.AvgSaveElapsedMs)}", string.Empty, nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
-            this.SnapshotMetricMinSaveElapsedMsGauge = Metrics.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MinSaveElapsedMs)}", string.Empty, nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
+            var labelNames = (nameof(SnapshotMetric.Actor), nameof(SnapshotMetric.Snapshot));
+            
+            this.SnapshotMetricSaveCountGauge = metricFactory.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.SaveCount)}", string.Empty, labelNames);
+            this.SnapshotMetricMaxElapsedVersionGauge = metricFactory.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MaxElapsedVersion)}", string.Empty, labelNames);
+            this.SnapshotMetricAvgElapsedVersionGauge = metricFactory.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.AvgElapsedVersion)}", string.Empty, labelNames);
+            this.SnapshotMetricMinElapsedVersionGauge = metricFactory.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MinElapsedVersion)}", string.Empty, labelNames);
+            this.SnapshotMetricMaxSaveElapsedMsGauge = metricFactory.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MaxSaveElapsedMs)}", string.Empty, labelNames);
+            this.SnapshotMetricAvgSaveElapsedMsGauge = metricFactory.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.AvgSaveElapsedMs)}", string.Empty, labelNames);
+            this.SnapshotMetricMinSaveElapsedMsGauge = metricFactory.CreateGauge($"{nameof(SnapshotMetric)}_{nameof(SnapshotMetric.MinSaveElapsedMs)}", string.Empty, labelNames);
         }
 
         public void Handle(List<SnapshotMetric> snapshotMetrics)
         {
             foreach (var item in snapshotMetrics)
             {
-                this.SnapshotMetricSaveCountGauge.WithLabels(item.Actor, item.Snapshot).Set(item.SaveCount, item.Timestamp);
-                this.SnapshotMetricMaxElapsedVersionGauge.WithLabels(item.Actor, item.Snapshot).Set(item.MaxElapsedVersion, item.Timestamp);
-                this.SnapshotMetricAvgElapsedVersionGauge.WithLabels(item.Actor, item.Snapshot).Set(item.AvgElapsedVersion, item.Timestamp);
-                this.SnapshotMetricMinElapsedVersionGauge.WithLabels(item.Actor, item.Snapshot).Set(item.MinElapsedVersion, item.Timestamp);
-                this.SnapshotMetricMaxSaveElapsedMsGauge.WithLabels(item.Actor, item.Snapshot).Set(item.MaxSaveElapsedMs, item.Timestamp);
-                this.SnapshotMetricAvgSaveElapsedMsGauge.WithLabels(item.Actor, item.Snapshot).Set(item.AvgSaveElapsedMs, item.Timestamp);
-                this.SnapshotMetricMinSaveElapsedMsGauge.WithLabels(item.Actor, item.Snapshot).Set(item.MinSaveElapsedMs, item.Timestamp);
+                var labels = (item.Actor, item.Snapshot);
+                
+                this.SnapshotMetricSaveCountGauge.WithLabels(labels).Set(item.SaveCount, item.Timestamp);
+                this.SnapshotMetricMaxElapsedVersionGauge.WithLabels(labels).Set(item.MaxElapsedVersion, item.Timestamp);
+                this.SnapshotMetricAvgElapsedVersionGauge.WithLabels(labels).Set(item.AvgElapsedVersion, item.Timestamp);
+                this.SnapshotMetricMinElapsedVersionGauge.WithLabels(labels).Set(item.MinElapsedVersion, item.Timestamp);
+                this.SnapshotMetricMaxSaveElapsedMsGauge.WithLabels(labels).Set(item.MaxSaveElapsedMs, item.Timestamp);
+                this.SnapshotMetricAvgSaveElapsedMsGauge.WithLabels(labels).Set(item.AvgSaveElapsedMs, item.Timestamp);
+                this.SnapshotMetricMinSaveElapsedMsGauge.WithLabels(labels).Set(item.MinSaveElapsedMs, item.Timestamp);
             }
         }
     }

--- a/src/Ray.Metric.Prometheus/MetricHandler/SnapshotSummaryMetricHandler.cs
+++ b/src/Ray.Metric.Prometheus/MetricHandler/SnapshotSummaryMetricHandler.cs
@@ -1,27 +1,27 @@
-﻿using Prometheus.Client;
+﻿using Prometheus.Client.Abstractions;
 using Ray.Metric.Core.Element;
 
 namespace Ray.Metric.Prometheus.MetricHandler
 {
     public class SnapshotSummaryMetricHandler
     {
-        private readonly Gauge SnapshotSummaryMetricSaveCountGauge;
-        private readonly Gauge SnapshotSummaryMetricMaxElapsedVersionGauge;
-        private readonly Gauge SnapshotSummaryMetricAvgElapsedVersionGauge;
-        private readonly Gauge SnapshotSummaryMetricMinElapsedVersionGauge;
-        private readonly Gauge SnapshotSummaryMetricMaxSaveElapsedMsGauge;
-        private readonly Gauge SnapshotSummaryMetricAvgSaveElapsedMsGauge;
-        private readonly Gauge SnapshotSummaryMetricMinSaveElapsedMsGauge;
+        private readonly IGauge SnapshotSummaryMetricSaveCountGauge;
+        private readonly IGauge SnapshotSummaryMetricMaxElapsedVersionGauge;
+        private readonly IGauge SnapshotSummaryMetricAvgElapsedVersionGauge;
+        private readonly IGauge SnapshotSummaryMetricMinElapsedVersionGauge;
+        private readonly IGauge SnapshotSummaryMetricMaxSaveElapsedMsGauge;
+        private readonly IGauge SnapshotSummaryMetricAvgSaveElapsedMsGauge;
+        private readonly IGauge SnapshotSummaryMetricMinSaveElapsedMsGauge;
 
-        public SnapshotSummaryMetricHandler()
+        public SnapshotSummaryMetricHandler(IMetricFactory metricFactory)
         {
-            this.SnapshotSummaryMetricSaveCountGauge = Metrics.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.SaveCount)}", string.Empty);
-            this.SnapshotSummaryMetricMaxElapsedVersionGauge = Metrics.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MaxElapsedVersion)}", string.Empty);
-            this.SnapshotSummaryMetricAvgElapsedVersionGauge = Metrics.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.AvgElapsedVersion)}", string.Empty);
-            this.SnapshotSummaryMetricMinElapsedVersionGauge = Metrics.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MinElapsedVersion)}", string.Empty);
-            this.SnapshotSummaryMetricMaxSaveElapsedMsGauge = Metrics.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MaxSaveElapsedMs)}", string.Empty);
-            this.SnapshotSummaryMetricAvgSaveElapsedMsGauge = Metrics.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.AvgSaveElapsedMs)}", string.Empty);
-            this.SnapshotSummaryMetricMinSaveElapsedMsGauge = Metrics.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MinSaveElapsedMs)}", string.Empty);
+            this.SnapshotSummaryMetricSaveCountGauge = metricFactory.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.SaveCount)}", string.Empty);
+            this.SnapshotSummaryMetricMaxElapsedVersionGauge = metricFactory.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MaxElapsedVersion)}", string.Empty);
+            this.SnapshotSummaryMetricAvgElapsedVersionGauge = metricFactory.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.AvgElapsedVersion)}", string.Empty);
+            this.SnapshotSummaryMetricMinElapsedVersionGauge = metricFactory.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MinElapsedVersion)}", string.Empty);
+            this.SnapshotSummaryMetricMaxSaveElapsedMsGauge = metricFactory.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MaxSaveElapsedMs)}", string.Empty);
+            this.SnapshotSummaryMetricAvgSaveElapsedMsGauge = metricFactory.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.AvgSaveElapsedMs)}", string.Empty);
+            this.SnapshotSummaryMetricMinSaveElapsedMsGauge = metricFactory.CreateGauge($"{nameof(SnapshotSummaryMetric)}_{nameof(SnapshotSummaryMetric.MinSaveElapsedMs)}", string.Empty);
         }
 
         public void Handle(SnapshotSummaryMetric snapshotSummaryMetrics)

--- a/src/Ray.Metric.Prometheus/Ray.Metric.Prometheus.csproj
+++ b/src/Ray.Metric.Prometheus/Ray.Metric.Prometheus.csproj
@@ -3,8 +3,8 @@
 
   <ItemGroup>
     <PackageReference Include="Prometheus.Client" />
+    <PackageReference Include="Prometheus.Client.DependencyInjection" />
     <PackageReference Include="Prometheus.Client.MetricPusher" />
-    <PackageReference Include="Prometheus.Client.MetricServer" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ray.Metric.Core\Ray.Metric.Core.csproj" />


### PR DESCRIPTION
Bump Prometheus.Client to v.4.1.0 and use ValueTuple labels API.

Also I've removed reference to Prometheus.Client.MetricServer which seems to be unused.

I've resolved build errors because of breaking changes in our v4 release, but I was not able to check if endpoint works as expected. Can you please run example application to ensure metrics are being updated and reported correctly?